### PR TITLE
Add support for more types

### DIFF
--- a/antelopy/serializers/keys.py
+++ b/antelopy/serializers/keys.py
@@ -22,6 +22,12 @@ def serialize_public_key(s: str):
         key_type = KEY_TYPES["k1"]
         buf += struct.pack("b", key_type)
         buf += base58.b58decode(s[3:])[:-4]
+    elif s[:3] == "PUB":
+        key_type = KEY_TYPES[s[4:6].lower()]
+        sig = s[7:]
+        buf = b""
+        buf += struct.pack("b", key_type)
+        buf += base58.b58decode(sig)[:-4]
     return buf
 
 

--- a/antelopy/types/abi.py
+++ b/antelopy/types/abi.py
@@ -204,7 +204,7 @@ class Abi(AbiBaseClass):
             raise Exception(f"Type {t} isn't handled yet")
         return buf
 
-    def serialize_list(self, t: AbiType | AbiStructField, value: List[Any]) -> bytes:
+    def serialize_list(self, t: Union[AbiType, AbiStructField], value: List[Any]) -> bytes:
         buf = b""
         buf += varints.serialize_varint(len(value))
         for i in value:

--- a/antelopy/types/abi.py
+++ b/antelopy/types/abi.py
@@ -1,3 +1,4 @@
+import binascii
 import struct
 from typing import Any, List, Union, cast
 
@@ -179,6 +180,19 @@ class Abi(AbiBaseClass):
             buf += time_points.serialize_time_point(value)
         elif t == "time_point_sec":
             buf += time_points.serialize_time_point_sec(value)
+        elif t.startswith("checksum"):
+            if isinstance(value, str):
+                buf += bytes.fromhex(value)
+            elif isinstance(value, bytes):
+                try:
+                    # test if hex-encoded bytes
+                    value = binascii.unhexlify(value)
+                except:
+                    ...
+                if len(value) in [20, 32, 64]:
+                    buf += value
+            else:
+                raise ValueError(f"serializing checksums expects str or bytes format")
         else:
             raise Exception(f"Type {t} isn't handled yet")
         return buf

--- a/antelopy/types/types.py
+++ b/antelopy/types/types.py
@@ -25,9 +25,9 @@ DEFAULT_TYPES = {
     "name": "",
     "bytes": "",
     "string": "",
-    "checksum160": "",  # TODO
-    "checksum256": "",  # TODO
-    "checksum512": "",  # TODO
+    "checksum160": "",
+    "checksum256": "",
+    "checksum512": "",
     "public_key": "",
     "signature": "",
     "symbol": "",

--- a/antelopy/types/types.py
+++ b/antelopy/types/types.py
@@ -14,8 +14,8 @@ DEFAULT_TYPES = {
     "uint64": "q",
     "int128": "",  # TODO Struct doesn't natively 128bit support, so split before encoding
     "uint128": "",  # TODO Struct doesn't natively 128bit support, so split before encoding
-    "varint32": "",  # TODO # Zigzag, to varuint
-    "varuint32": "",  # TODO # varuint, pad to 32 bit
+    "varint32": "",  
+    "varuint32": "", 
     "float32": "f",
     "float64": "d",
     "float128": "",  # TODO Struct doesn't natively 128bit support, so split before encoding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "antelopy"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python helper for Antelope transaction serialization"
 authors = ["Jake Hattwell <stuck@sixpm.dev>"]
 license = "MIT"

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ![Workflow Badge](https://github.com/stuckatsixpm/antelopy/actions/workflows/main.yml/badge.svg?branch=main) ![Python version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue) ![PyPI](https://img.shields.io/pypi/v/antelopy?label=PyPI)
 
-*v0.1.3 - initial release*
+*v0.1.4 - initial release*
 
 Drop-in Python ABI cache for Antelope chains with local serialization support. 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def abi_cache():
     cache.read_abi_from_json("craft.tag", "tests/data/craft.tag.abi")
     cache.read_abi_from_json("atomicassets", "tests/data/atomicassets.abi")
     cache.read_abi_from_json("farmersworld", "tests/data/farmersworld.abi")
+    cache.read_abi_from_json("mock", "tests/data/mock.abi")
     # read from chain
     cache.read_abi("atomictoolsx")
     return cache

--- a/tests/data/mock.abi
+++ b/tests/data/mock.abi
@@ -1,0 +1,38 @@
+{
+  "version": "eosio::abi/1.2",
+  "types": [
+  ],
+  "structs": [
+    {
+      "name": "chksummock",
+      "base": "",
+      "fields": [
+        {
+          "name": "c160",
+          "type": "checksum160"
+        },
+        {
+          "name": "c256",
+          "type": "checksum256"
+        },
+        {
+          "name": "c512",
+          "type": "checksum512"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "name": "chksummock",
+      "type": "chksummock",
+      "ricardian_contract": ""
+    }
+  ],
+  "tables": [],
+  "ricardian_clauses": [],
+  "error_messages": [],
+  "abi_extensions": [],
+  "variants": [],
+  "action_results": []
+}

--- a/tests/data/mock.abi
+++ b/tests/data/mock.abi
@@ -20,12 +20,31 @@
           "type": "checksum512"
         }
       ]
+    },
+    {
+      "name": "varintmock",
+      "base": "",
+      "fields": [
+        {
+          "name": "vuint32",
+          "type": "varuint32"
+        },
+        {
+          "name": "vint32",
+          "type": "varint32"
+        }
+      ]
     }
   ],
   "actions": [
     {
       "name": "chksummock",
       "type": "chksummock",
+      "ricardian_contract": ""
+    },
+    {
+      "name": "varintmock",
+      "type": "varintmock",
       "ricardian_contract": ""
     }
   ],

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -2,7 +2,7 @@ from binascii import hexlify
 from antelopy.serializers import keys
 
 
-def test_serialize_key():
+def test_serialize_eos_key():
     assert (
         hexlify(
             keys.serialize_public_key(
@@ -11,6 +11,17 @@ def test_serialize_key():
         )
         == b"00027765c671e9a9dc0053796a96a5d2e80a04e97f97ea28e53efddb455157a7da1c"
     ), "EOS Public Key to Key bytes failed"
+
+
+def test_serialize_pub_k1_key():
+    assert (
+        hexlify(
+            keys.serialize_public_key(
+                "PUB_K1_5m4K6EFnMEmAUekqnxqfaM5b2vCJFooD9JH352iXJDQ9zdcMZH"
+            )
+        )
+        == b"000272d2489a5b63d69bddf270c1ff7870a20799ca0f4c445a682e4a982d2061c9d8"
+    ), "PUB_K1 formatted Key to Key bytes failed"
 
 
 def test_serialize_signature():

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -1,0 +1,18 @@
+import hashlib
+from binascii import hexlify
+from antelopy import AbiCache
+
+
+def test_serialize_checksums(abi_cache: AbiCache):
+    raw_string = "The quick brown fox jumps over the lazy dog."
+    # c256 tests hex formatted bytes
+    # c512 tests bytes
+    data = {
+        "c160": hashlib.sha1(raw_string.encode()).hexdigest(),
+        "c256": bytes.fromhex(hashlib.sha256(raw_string.encode()).hexdigest()),
+        "c512": hashlib.sha512(raw_string.encode()).hexdigest().encode(),
+    }
+    s = abi_cache.serialize_data("mock", "chksummock", data)
+    assert (
+        s == data["c160"].encode() + hexlify(data["c256"]) + data["c512"]
+    ), "checksum conversion failed"

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -16,3 +16,13 @@ def test_serialize_checksums(abi_cache: AbiCache):
     assert (
         s == data["c160"].encode() + hexlify(data["c256"]) + data["c512"]
     ), "checksum conversion failed"
+
+def test_serialize_abi_varints(abi_cache: AbiCache):
+    data = {
+        "vuint32": 4294967295,
+        "vint32": -2147483647
+    }
+    s = abi_cache.serialize_data("mock", "varintmock", data)
+    assert (
+        s == b''
+    ), "varint conversion failed"

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -24,5 +24,5 @@ def test_serialize_abi_varints(abi_cache: AbiCache):
     }
     s = abi_cache.serialize_data("mock", "varintmock", data)
     assert (
-        s == b''
+        s == b'ffffffff0ffdffffff0f'
     ), "varint conversion failed"


### PR DESCRIPTION
* Adds support for checksum, pub_ formatted public keys, and varuint/varint32s as field types.
* Tests extended to cover new serializers
* Bump version to v0.1.4
