### PR TITLE
Add internal base58 implementation to avoid dependency conflicts

### DIFF
--- a/antelopy/serializers/keys.py
+++ b/antelopy/serializers/keys.py
@@ -3,8 +3,7 @@
 Utility functions to serialize EOS keys and signatures into bytes"""
 
 import struct
-
-import base58
+from ..utils.base58 import b58decode, b58encode
 
 KEY_TYPES = {
     "k1": 0,
@@ -21,13 +20,13 @@ def serialize_public_key(s: str):
     if s[:3] == "EOS":
         key_type = KEY_TYPES["k1"]
         buf += struct.pack("b", key_type)
-        buf += base58.b58decode(s[3:])[:-4]
+        buf += b58decode(s[3:])[:-4]
     elif s[:3] == "PUB":
         key_type = KEY_TYPES[s[4:6].lower()]
         sig = s[7:]
         buf = b""
         buf += struct.pack("b", key_type)
-        buf += base58.b58decode(sig)[:-4]
+        buf += b58decode(sig)[:-4]
     return buf
 
 
@@ -37,5 +36,5 @@ def serialize_signature(s: str):
     sig = s[7:]
     buf = b""
     buf += struct.pack("b", key_type)
-    buf += base58.b58decode(sig)[:-4]
+    buf += b58decode(sig)[:-4]
     return buf

--- a/antelopy/types/abi.py
+++ b/antelopy/types/abi.py
@@ -183,9 +183,9 @@ class Abi(AbiBaseClass):
             buf += time_points.serialize_time_point(value)
         elif t == "time_point_sec":
             buf += time_points.serialize_time_point_sec(value)
-        elif t in ["varuint32","varint32"]:
+        elif t in ["varuint32", "varint32"]:
             if t == "varint32":
-                value = (value << 1) ^ (value >> 31) # 32-1
+                value = (value << 1) ^ (value >> 31)  # 32-1
             buf += varints.serialize_varint(value)
         elif t.startswith("checksum"):
             if isinstance(value, str):
@@ -204,7 +204,9 @@ class Abi(AbiBaseClass):
             raise Exception(f"Type {t} isn't handled yet")
         return buf
 
-    def serialize_list(self, t: Union[AbiType, AbiStructField], value: List[Any]) -> bytes:
+    def serialize_list(
+        self, t: Union[AbiType, AbiStructField], value: List[Any]
+    ) -> bytes:
         buf = b""
         buf += varints.serialize_varint(len(value))
         for i in value:

--- a/antelopy/types/types.py
+++ b/antelopy/types/types.py
@@ -14,8 +14,8 @@ DEFAULT_TYPES = {
     "uint64": "q",
     "int128": "",  # TODO Struct doesn't natively 128bit support, so split before encoding
     "uint128": "",  # TODO Struct doesn't natively 128bit support, so split before encoding
-    "varint32": "",  
-    "varuint32": "", 
+    "varint32": "",
+    "varuint32": "",
     "float32": "f",
     "float64": "d",
     "float128": "",  # TODO Struct doesn't natively 128bit support, so split before encoding

--- a/antelopy/utils/base58.py
+++ b/antelopy/utils/base58.py
@@ -10,7 +10,7 @@ alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 def b58encode(b: Union[bytes, str]) -> bytes:
     if isinstance(b, str):
-        b = b.encode()
+        b = b.encode("ascii")
     r = b""
     zeros = 0
     for i in b:
@@ -21,14 +21,14 @@ def b58encode(b: Union[bytes, str]) -> bytes:
     n = int.from_bytes(b, "big")
     pos = 0
     while n:
-        n,mod = divmod(n,58)
+        n, mod = divmod(n, 58)
         r = alphabet[mod].encode() + r
     return b"1" * zeros + r
 
 
 def b58decode(b: Union[bytes, str]) -> bytes:
     if isinstance(b, str):
-        b = b.encode()
+        b = b.encode("ascii")
     ones = 0
     for i in b:
         if chr(i) == "1":

--- a/antelopy/utils/base58.py
+++ b/antelopy/utils/base58.py
@@ -1,0 +1,43 @@
+"""base58.py
+
+Implementation of base58 encoding because no version of base58 is compatible
+with aioeos, eospy, and pyntelope :P
+"""
+from typing import Union
+
+alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def b58encode(b: Union[bytes, str]) -> bytes:
+    if isinstance(b, str):
+        b = b.encode()
+    r = b""
+    zeros = 0
+    for i in b:
+        if i == 0:
+            zeros += 1
+        else:
+            break
+    n = int.from_bytes(b, "big")
+    pos = 0
+    while n:
+        n,mod = divmod(n,58)
+        r = alphabet[mod].encode() + r
+    return b"1" * zeros + r
+
+
+def b58decode(b: Union[bytes, str]) -> bytes:
+    if isinstance(b, str):
+        b = b.encode()
+    ones = 0
+    for i in b:
+        if chr(i) == "1":
+            ones += 1
+        else:
+            break
+    r = 0
+    p = 1
+    for i in b:
+        r += (58 ** (len(b) - p)) * alphabet.index(chr(i))
+        p += 1
+    return b"\x00" * ones + r.to_bytes((r.bit_length() + 7) // 8, "big")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ homepage = "https://github.com/stuckatsixpm/antelopy"
 python = "^3.8"
 requests = "^2.31.0"
 pydantic = "^2.4.2"
-base58 = "2.0.0"
 
 [tool.poetry.dev-dependencies]
 black = "^23.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Python helper for Antelope transaction serialization"
 authors = ["Jake Hattwell <stuck@sixpm.dev>"]
 license = "MIT"
 readme = "readme.md"
-homepage = "https://python-poetry.org/"
+homepage = "https://github.com/stuckatsixpm/antelopy"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "antelopy"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python helper for Antelope transaction serialization"
 authors = ["Jake Hattwell <stuck@sixpm.dev>"]
 license = "MIT"

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ![Workflow Badge](https://github.com/stuckatsixpm/antelopy/actions/workflows/main.yml/badge.svg?branch=main) ![Python version](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue) ![PyPI](https://img.shields.io/pypi/v/antelopy?label=PyPI)
 
-*v0.1.4 - initial release*
+*v0.1.5 - initial release*
 
 Drop-in Python ABI cache for Antelope chains with local serialization support. 
 

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -17,12 +17,8 @@ def test_serialize_checksums(abi_cache: AbiCache):
         s == data["c160"].encode() + hexlify(data["c256"]) + data["c512"]
     ), "checksum conversion failed"
 
+
 def test_serialize_abi_varints(abi_cache: AbiCache):
-    data = {
-        "vuint32": 4294967295,
-        "vint32": -2147483647
-    }
+    data = {"vuint32": 4294967295, "vint32": -2147483647}
     s = abi_cache.serialize_data("mock", "varintmock", data)
-    assert (
-        s == b'ffffffff0ffdffffff0f'
-    ), "varint conversion failed"
+    assert s == b"ffffffff0ffdffffff0f", "varint conversion failed"


### PR DESCRIPTION
No version of base58 works for all three of pyntelope, aioeos, and eospy, so for compatibility, I've added an implementation of base58 encoding w/ standard bitcoin alphabet