### PR TITLE
Fix type handling for optional and list in abi.py

### DIFF
--- a/antelopy/types/abi.py
+++ b/antelopy/types/abi.py
@@ -43,11 +43,12 @@ class AbiStructField(AbiBaseClass):
 
     def __init__(self, **data: Any):
         super().__init__(**data)
-        if self.type.endswith("[]"):
-            self.is_list = True
-            self.type = self.type[:-2]
         if self.type.endswith("$"):
             self.optional = True
+            self.type = self.type[:-1]   # strip the "$"
+        if self.type.endswith("[]"):
+            self.is_list = True
+            self.type = self.type[:-2]   # strip the "[]"
 
 
 class AbiStruct(AbiBaseClass):


### PR DESCRIPTION
when we see $  need to strip it out.
also to handle edge scenario,  we should strip the $ 1st, and then []. to handle like:
name[]$

code supports these types:
name
name$
name[]
name[]$